### PR TITLE
Format leaderboard announcement time in minutes and seconds, add commas to score

### DIFF
--- a/K.O.R Server/Services/WebhookService.cs
+++ b/K.O.R Server/Services/WebhookService.cs
@@ -48,10 +48,12 @@ public class WebhookService : EndpointService
 
     public void AnnounceLeaderboardEntry(LeaderboardEntry entry, int place)
     {
+        TimeSpan time = TimeSpan.FromSeconds(entry.Time);
+        
         EmbedBuilder builder = new EmbedBuilder()
             .WithTimestamp(entry.CreationDate)
             .WithTitle($"{entry.User.Username} just achieved #{place}!")
-            .WithDescription($"{entry.Score} points in {entry.Time} seconds");
+            .WithDescription($"{entry.Score:N0} points in {time:mm\\:ss}");
 
         switch (place)
         {


### PR DESCRIPTION
In the AnnounceLeaderboardEntry method, the time associated with a leaderboard score was previously displayed in seconds only. This commit modifies this to display in a more user-friendly minutes and seconds format. The change will improve usability by making leaderboard times easier to read and compare.

Additionally, scores are now properly formatted with commas (e.g. 1000 -> 1,000) which makes it look nicer.